### PR TITLE
Fix 404 Error when using different Decimal symbol

### DIFF
--- a/API/MicrosoftStore/UrlEx.cs
+++ b/API/MicrosoftStore/UrlEx.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Marketplace.Storefront.Contracts
 
         public static IFlurlRequest GetStorefrontBase(CultureInfo culture = null, double version = 9.0)
         {
-            return Constants.STOREFRONT_API_HOST.AppendPathSegment("v" + version.ToString("0.0")).GetBase(culture);
+            return Constants.STOREFRONT_API_HOST.AppendPathSegment("v" + version.ToString("0.0", CultureInfo.InvariantCulture)).GetBase(culture);
         }
     }
 }


### PR DESCRIPTION
double.ToString() returns Region-based strings, and when you expect it to return "0.9" it returns "0/9" or even "0,9" based on user's preference, but this will break API. Using CultureInfo.CultureInvariant fixes this problem for people using different number formats.