### PR TITLE
Fix 404 Error when using different Decimal symbol

### DIFF
--- a/API/MicrosoftStore/UrlEx.cs
+++ b/API/MicrosoftStore/UrlEx.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Marketplace.Storefront.Contracts
 
         public static IFlurlRequest GetStorefrontBase(CultureInfo culture = null, double version = 9.0)
         {
-            return Constants.STOREFRONT_API_HOST.AppendPathSegment("v" + version.ToString("0.0")).GetBase(culture);
+            return Constants.STOREFRONT_API_HOST.AppendPathSegment("v" + version.ToString("0.0", CultureInfo.InvariantCulture)).GetBase(culture);
         }
     }
 }

--- a/API/StoreEdgeFD/BusinessLogic/UrlEx.cs
+++ b/API/StoreEdgeFD/BusinessLogic/UrlEx.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Marketplace.Storefront.StoreEdgeFD.BusinessLogic
 
         public static Url GetStoreEdgeFDBase(CultureInfo culture = null, double version = 9.0)
         {
-            return Constants.STOREFRONT_API_HOST.AppendPathSegment("v" + version.ToString("0.0")).SetMarket(culture);
+            return Constants.STOREFRONT_API_HOST.AppendPathSegment("v" + version.ToString("0.0", CultureInfo.InvariantCulture)).SetMarket(culture);
         }
     }
 }


### PR DESCRIPTION
ToString() method on double returns a string with region-specific decimal symbol. Fluent Store expencts "." to be decimal symbol while some users may use other symbols. This causes to generated urls for accessing store be invalid and user get a 404 error.