### PR TITLE
Fix IPFS Gateway link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Several sources are currently supported, with several more planned for the futur
 
 ## Where to download?
 - [GitHub Releases](https://github.com/yoshiask/FluentStore/releases)
-- [IPFS Gateway](https://ipfs.askharoun.com/FluentStore/BetaInstaller/FluentStoreBeta.appinstaller)
+- [IPFS Gateway](https://ipfs.askharoun.com/FluentStore/BetaInstaller/FluentStoreBeta.appinstaller?filename=FluentStoreBeta.appinstaller&download=true)
 
 ## Frequently Asked Questions
 ### What are the system requirements?


### PR DESCRIPTION
Updated IPFS Gateway link to include download parameter. 

Per the [path gateway spec](http://specs.ipfs.tech/http-gateways/path-gateway/#download-request-query-parameter) this forces responses to include `Content-Disposition: attachment[;filename=...]` which browsers will "present as a 'Save as' dialog" instead of showing the user the raw XML and expecting them to know to save it. 